### PR TITLE
Fix of K/M/G values in critical alarms

### DIFF
--- a/check_nexenta.py
+++ b/check_nexenta.py
@@ -291,7 +291,7 @@ def check_spaceusage(nexenta):
                         rc.RC = NagiosStates.CRITICAL
                         errors.append("CRITICAL: %s %.0f%% full!" % (vol, volusedprc))
                         continue
-                elif convert_space(volcrit) <= convert_space(available):
+                elif convert_space(volcrit) >= convert_space(available):
                     rc.RC = NagiosStates.CRITICAL
                     errors.append("CRITICAL: %s %s available!" % (vol, available))
                     continue


### PR DESCRIPTION
Not sure if this is a bug, but in our systems we're getting a error when the free space in the folder exceeded that as defined as the critical threshold.

Fixed by this commit
