### PR TITLE
Fixes issue #5 - SSL Certificate context / add support for Nexenta 4.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Features
 
 Supports
 ========
-* NexentaStor 3.1.2/3.1.3/3.1.3.5/3.1.4/3.1.4.1/3.1.5
+* NexentaStor 3.1.2/3.1.3/3.1.3.5/3.1.4/3.1.4.1/3.1.5/4.0.X
 * HTTP and HTTPS
 * SNMPv2 and SNMPv3
 * Python 2.4/2.6/2.7

--- a/check_nexenta.cfg
+++ b/check_nexenta.cfg
@@ -8,6 +8,7 @@
 # api_user          # username for API connection            ##
 # api_pass          # password for API connection            ##
 # api_ssl           # set to ON to use HTTP-SSL (https://)   ##
+# api_ssl_insecure  # do not verify certificates             ##
 # space_threshold   # check space usage for these folders    ##
 # skip_trigger      # set to ON to disable trigger check     ##
 # skip_folderperf   # set to ON to skip perfdata for folders ##
@@ -36,6 +37,7 @@ api_port = 2004
 api_user = check_nexenta 
 api_pass = xxxxx
 api_ssl = ON
+api_ssl_insecure = ON
 snmp_community = public
 snmp_port = 8082
 skip_folderperf = ON


### PR DESCRIPTION
Fixes SSL certificate validation errors you always get when using IP addresses by adding a new config parameter.

`CRITICAL: Unable to connect to API at https://XX.XX.XX.XX:8443/rest/nms/ <https://XX.XX.XX.XX:8443/rest/nms/>`

because of hidden `urllib2.URLError: <urlopen error [SSL: CERTIFICATE_VERIFY_FAILED]`

Further, fixes a minor parameter mismatch witch prevented use of `-P` (perfdata):
`Fewer items found in D-Bus signature than in Python arguments`

Tested against Nexenta 4.0.X Appliance
